### PR TITLE
Replace `aes_string()`

### DIFF
--- a/R/ggswissmaps_00funs.R
+++ b/R/ggswissmaps_00funs.R
@@ -37,9 +37,9 @@ theme_white_f <- function(base_size = 12, base_family = ""){
 maps2_ <- 
   function(data,
            mapping = 
-             ggplot2::aes_string(x = "long",
-                                 y = "lat",
-                                 group = "group"),
+             ggplot2::aes(x = .data[["long"]],
+                          y = .data[["lat"]],
+                          group = .data[["group"]]),
            caption = "Boundaries: BFS GEOSTAT / swisstopo"){
     ggplot2::ggplot(data = data, mapping = mapping) +
     ggplot2::geom_path() +

--- a/man/maps2_.Rd
+++ b/man/maps2_.Rd
@@ -7,7 +7,8 @@ and latitude (lat) coordinates, as a 'ggplot2' object}
 \usage{
 maps2_(
   data,
-  mapping = ggplot2::aes_string(x = "long", y = "lat", group = "group"),
+  mapping = ggplot2::aes(x = .data[["long"]], y = .data[["lat"]], group =
+    .data[["group"]]),
   caption = "Boundaries: BFS GEOSTAT / swisstopo"
 )
 }


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue is the deprecated use of `ggplot2::aes_string()`.
Normally, this would not generate a problem at all, but because it is used in the formals of a function, it emits a warning at build time (rather than at runtime).
I figured the best solution would just be to update the offending function.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit an update to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun